### PR TITLE
Allow setting SSL certificate for secure curl

### DIFF
--- a/PiwikTracker.php
+++ b/PiwikTracker.php
@@ -1326,6 +1326,8 @@ class PiwikTracker
                     'Accept-Language: ' . $this->acceptLanguage
                 ));
 
+            if (defined('PATH_TO_CERTIFICATES_FILE')) $options[CURLOPT_CAINFO] = PATH_TO_CERTIFICATES_FILE;
+
             switch ($method) {
                 case 'POST':
                     $options[CURLOPT_POST] = TRUE;


### PR DESCRIPTION
This took me hours to figure out why my tracking script wouldn't connect sucessfully with my Piwik installation. Both my PHP script and Piwik were on the same server, which has an SSL certificate set up. So, I was setting PiwikTracker's Piwik base URL (class static variable `$URL`) as `https://www.mysitecom/piwik`.

And the tracking script wasn't working. If I changed `$URL` to `http://www.mysitecom/piwik`, however, it WOULD work.

Troubleshooting with curl on the command line with `curl https://www.mysitecom/piwik` showed me a useful error:

`curl: (60) SSL certificate problem, verify that the CA cert is OK. Details:
error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed`

These links helped me figure out what was going on, and how to fix it:
http://stackoverflow.com/questions/6400300/https-and-ssl3-get-server-certificatecertificate-verify-failed-ca-is-ok
http://curl.haxx.se/docs/sslcerts.html
http://php.net/manual/en/function.curl-setopt.php
http://curl.haxx.se/ca/cacert.pem

I am submitting my proposed changes as a pull request, as there may be a more graceful way to do this. But whichever way it is done, for using PiwikTracker in shared hosting environments (in my case, Dreamhost), it would seem essential to allow some method setting a path to certificates at run time.

In this solution, I set the `PATH_TO_CERTIFICATES_FILE` constant from my tracking script before I instantiate the PiwikTracker class. However, the authors may wish to instead use a class variable and an associated setter method instead.
